### PR TITLE
chore: remove python dependency from persia-common

### DIFF
--- a/rust/persia-common/src/lib.rs
+++ b/rust/persia-common/src/lib.rs
@@ -120,25 +120,11 @@ pub struct SparseBatch {
     pub batcher_idx: Option<usize>,
 }
 
-impl SparseBatch {
-    pub fn new(batches: Vec<(String, Vec<&PyArray1<u64>>)>, requires_grad: Option<bool>) -> Self {
+impl Default for SparseBatch {
+    fn default() -> Self {
         SparseBatch {
-            requires_grad: requires_grad.unwrap_or(true),
-            batches: batches
-                .into_iter()
-                .map(|(feature_name, batch)| {
-                    let indices = batch
-                        .iter()
-                        .map(|x| {
-                            x.readonly()
-                                .as_slice()
-                                .expect("cannot read np array")
-                                .to_vec()
-                        })
-                        .collect();
-                    FeatureBatch::new(feature_name, indices)
-                })
-                .collect(),
+            requires_grad: false,
+            batches: Vec::new(),
             enter_forward_id_buffer_time: None,
             enter_post_forward_buffer_time: None,
             batcher_idx: None,

--- a/rust/persia-common/src/lib.rs
+++ b/rust/persia-common/src/lib.rs
@@ -13,7 +13,6 @@ use persia_libs::{
     hashbrown::HashMap,
     itertools::Itertools,
     ndarray::Array2,
-    numpy::PyArray1,
     serde::{self, Deserialize, Serialize},
 };
 

--- a/rust/persia-core/src/data.rs
+++ b/rust/persia-core/src/data.rs
@@ -106,7 +106,7 @@ impl PyPersiaBatchData {
     ) {
         self.inner.sparse_data = EmbeddingTensor::SparseBatch(SparseBatch {
             requires_grad: requires_grad.unwrap_or(true),
-            batches: batches
+            batches: sparse_data
                 .into_iter()
                 .map(|(feature_name, batch)| {
                     let indices = batch

--- a/rust/persia-core/src/data.rs
+++ b/rust/persia-core/src/data.rs
@@ -121,7 +121,7 @@ impl PyPersiaBatchData {
                     FeatureBatch::new(feature_name, indices)
                 })
                 .collect(),
-            ..SparseBatch::default(),
+            ..SparseBatch::default()
         });
     }
 


### PR DESCRIPTION
Resolved dependency of  `libpython.so` for `persia-middleware` and `persia-server`