### PR TITLE
chore: remove unused is_training flag in dataloader

### DIFF
--- a/persia/data.py
+++ b/persia/data.py
@@ -114,7 +114,6 @@ class Dataloder(object):
     Arguments:
         dataset (IterableChannelBase): dataset for Dataloder to retrive replica info and sender channel
         forward_buffer_size: (int, optional): gpu forward channel buffer size, this args effect the gpu memory cost
-        is_training (bool, optional): whether current forward status is training or not
         timeout_ms (int, optional): timeout for PyForward to fetch data, millisecond unit
         num_workers (int, optional): spawn thread worker number for  PyForward to lookup embedding and PythonBatchData prefetch
         reproducible (bool, optional): iterate the data in fixed order, make the dataflow deterministic
@@ -125,7 +124,6 @@ class Dataloder(object):
         self,
         dataset: IterableDataset,
         forward_buffer_size: int = 10,
-        is_training: bool = True,
         timeout_ms: int = 1000 * 60 * 10,
         num_workers: int = 10,
         reproducible: bool = False,
@@ -140,7 +138,6 @@ class Dataloder(object):
 
         self.forward_engine = Forward(
             forward_buffer_size,
-            is_training,
             reproducible,
             embedding_staleness,
         )

--- a/rust/persia-embedding-server/src/embedding_worker_service/mod.rs
+++ b/rust/persia-embedding-server/src/embedding_worker_service/mod.rs
@@ -1440,9 +1440,9 @@ impl EmbeddingWorker {
 
     pub async fn forward_batch_id(
         &self,
-        req: (IDTypeFeatureRemoteRef, bool),
+        id_type_feature_ref: IDTypeFeatureRemoteRef,
     ) -> Result<EmbeddingBatch, EmbeddingWorkerError> {
-        let resp = self.inner.forward_batch_id(req).await;
+        let resp = self.inner.forward_batch_id(id_type_feature_ref).await;
         if resp.is_err() {
             self.inner.error_handle(resp.as_ref().unwrap_err()).await?;
         }

--- a/rust/persia-embedding-server/src/embedding_worker_service/mod.rs
+++ b/rust/persia-embedding-server/src/embedding_worker_service/mod.rs
@@ -1030,13 +1030,12 @@ impl EmbeddingWorkerInner {
 
     pub async fn forward_batch_id(
         &self,
-        req: (IDTypeFeatureRemoteRef, bool),
+        id_type_feature_remote_ref: IDTypeFeatureRemoteRef,
     ) -> Result<EmbeddingBatch, EmbeddingWorkerError> {
-        let (id_type_feature_remote_ref, requires_grad) = req;
         let ref_id = id_type_feature_remote_ref.ref_id;
 
         let inner = self.clone();
-        let mut indices = {
+        let mut id_type_feature = {
             let mut forward_id_buffer = inner.forward_id_buffer.write().await;
             let sub_buffer = forward_id_buffer
                 .get_mut(&id_type_feature_remote_ref.batcher_idx)
@@ -1046,10 +1045,11 @@ impl EmbeddingWorkerInner {
                 .ok_or_else(|| EmbeddingWorkerError::ForwardIdNotFound(ref_id))?
         };
 
+        let requires_grad = id_type_feature.requires_grad;
         tracing::debug!("received forward_batch_id request");
         self.staleness.fetch_add(1, Ordering::AcqRel);
         let result = inner
-            .lookup_batched_all_slots(&mut indices, requires_grad)
+            .lookup_batched_all_slots(&mut id_type_feature, requires_grad)
             .await;
 
         if result.is_err() {
@@ -1058,12 +1058,12 @@ impl EmbeddingWorkerInner {
         let result = result?;
 
         if requires_grad {
-            indices.enter_post_forward_buffer_time = Some(SystemTime::now());
+            id_type_feature.enter_post_forward_buffer_time = Some(SystemTime::now());
             inner
                 .post_forward_buffer
                 .write()
                 .await
-                .insert(ref_id, indices);
+                .insert(ref_id, id_type_feature);
             tracing::debug!("indices inserted into post forward buffer");
         }
 


### PR DESCRIPTION
The `DataLoader` should be no status, use the flag `requires_grad` in ``IDTypeFeatureBatch`` instead.